### PR TITLE
[charts/admin-privileges] feat: using the new nonroot-v2

### DIFF
--- a/charts/admin-privileges/Chart.yaml
+++ b/charts/admin-privileges/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: admin-privileges
 description: Resources require admin privileged permission
-version: 1.0.1
+version: 1.0.2

--- a/charts/admin-privileges/README.md
+++ b/charts/admin-privileges/README.md
@@ -1,6 +1,6 @@
 # admin-privileges
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
 
 Resources require admin privileged permission
 

--- a/charts/admin-privileges/README.md
+++ b/charts/admin-privileges/README.md
@@ -15,12 +15,6 @@ helm repo add datarobot-oss https://datarobot-oss.github.io/helm-charts
 A simple install with default values:
 
 ```console
-helm install datarobot-oss/admin-privileges
-```
-
-To install the chart with the release name `my-release`:
-
-```console
 helm install my-release datarobot-oss/admin-privileges
 ```
 

--- a/charts/admin-privileges/README.md
+++ b/charts/admin-privileges/README.md
@@ -15,6 +15,12 @@ helm repo add datarobot-oss https://datarobot-oss.github.io/helm-charts
 A simple install with default values:
 
 ```console
+helm install datarobot-oss/admin-privileges
+```
+
+To install the chart with the release name `my-release`:
+
+```console
 helm install my-release datarobot-oss/admin-privileges
 ```
 

--- a/charts/admin-privileges/templates/role.yaml
+++ b/charts/admin-privileges/templates/role.yaml
@@ -47,7 +47,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  resourceNames: ["nonroot", "anyuid", "privileged"]
+  resourceNames: ["nonroot", "nonroot-v2", "anyuid", "privileged"]
   verbs: ["get", "use", "list"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]

--- a/ci/README.md.gotmpl
+++ b/ci/README.md.gotmpl
@@ -18,6 +18,12 @@ helm repo add datarobot-oss https://datarobot-oss.github.io/helm-charts
 A simple install with default values:
 
 ```console
+helm install datarobot-oss/{{ template "chart.name" . }}
+```
+
+To install the chart with the release name `my-release`:
+
+```console
 helm install my-release datarobot-oss/{{ template "chart.name" . }}
 ```
 

--- a/ci/README.md.gotmpl
+++ b/ci/README.md.gotmpl
@@ -18,12 +18,6 @@ helm repo add datarobot-oss https://datarobot-oss.github.io/helm-charts
 A simple install with default values:
 
 ```console
-helm install datarobot-oss/{{ template "chart.name" . }}
-```
-
-To install the chart with the release name `my-release`:
-
-```console
 helm install my-release datarobot-oss/{{ template "chart.name" . }}
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing to datarobot-oss/helm-charts! -->

## Description

update RBAC to use `nonroot-v2` security context constraints in openshift

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[charts/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/datarobot-oss/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
